### PR TITLE
fix: the tag of action name should be v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See [action.yml](action.yml)
 ```yaml
 steps:
   - uses: actions/checkout@master
-  - uses: manyuanrong/setup-ossutil@v1
+  - uses: manyuanrong/setup-ossutil@v1.0
     with:
       endpoint: "oss.aliyuncs.com"
       access-key-id: "your_key_id"


### PR DESCRIPTION
The tag should be v1.0 instead of v1, otherwise, the workflow will be failed while fetching action.