### PR TITLE
Update Node.js from 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ inputs:
     required: false
     default: ""
 runs:
-  using: "node12"
+  using: "node16"
   main: "index.js"


### PR DESCRIPTION
GitHub warns me in my actions:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: manyuanrong/setup-ossutil